### PR TITLE
Fixes for higher versions (1.17+)

### DIFF
--- a/src/main/java/io/github/nosequel/menu/Menu.java
+++ b/src/main/java/io/github/nosequel/menu/Menu.java
@@ -34,7 +34,7 @@ public abstract class Menu {
     private MenuType menuType = MenuType.INVENTORY;
 
     // the button type used for filling the inventory slots
-    private ItemStack fillerType = new ItemStack(Material.STAINED_GLASS_PANE, 1, DyeColor.BLACK.getData());
+    private ItemStack fillerType;
 
     /**
      * Constructor to make a new menu object


### PR DESCRIPTION
Removed Material.STAINED_GLASS_PANE because is not a material in newer API versions and will error.
This will make your API compatible with newer servers.